### PR TITLE
treasure: correctly check for skill milestone, not upgrade

### DIFF
--- a/js/layers/treasures.js
+++ b/js/layers/treasures.js
@@ -64,11 +64,11 @@ addLayer("t", {
     exponent() {
         let baseExp = new Decimal(0.5);
         
-        if (hasUpgrade('s', 24)) {
+        if (hasMilestone('s', 24)) {
             baseExp = baseExp.plus(0.025);
         }
 
-        if (hasUpgrade('s', 25)) {
+        if (hasMilestone('s', 25)) {
             baseExp = baseExp.plus(0.025);
         }
 


### PR DESCRIPTION
Skills have no upgrades, so the Skills milestones 24 and 25 had no
effect, when instead they're supposed to add 0.025 to the exponent of
Treasure.